### PR TITLE
Feature/게임 화면 구조 잡기 #8

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import GameStart from './screens/GameStart';
+import GamePlay from './screens/GamePlay';
 
 const App = () => {
-  return <div className="grid h-screen w-screen place-items-center">baseball game</div>;
+  const playMode = false;
+  // TODO const [playMode, setPlayMode] = useState(false);
+
+  return <div className="grid h-screen w-screen place-items-center">{playMode ? <GamePlay /> : <GameStart />}</div>;
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const App = () => {
-  return <div className="App">baseball game</div>;
+  return <div className="grid h-screen w-screen place-items-center">baseball game</div>;
 };
 
 export default App;

--- a/src/components/CountdownBar.tsx
+++ b/src/components/CountdownBar.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CountdownBar = () => {
+  return <div>시간 카운트 다운 바 섹션 입니다.</div>;
+};
+
+export default CountdownBar;

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NumberInput = () => {
+  return <div>숫자 입력 섹션</div>;
+};
+
+export default NumberInput;

--- a/src/components/PointInfo.tsx
+++ b/src/components/PointInfo.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PointInfo = () => {
+  return <div>획득 가능 포인트 섹션 입니다.</div>;
+};
+
+export default PointInfo;

--- a/src/components/TurnInfoBoard.tsx
+++ b/src/components/TurnInfoBoard.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TurnInfoBoard = () => {
+  return <div>모든 회차 정보 섹션 입니다.</div>;
+};
+
+export default TurnInfoBoard;

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const GamePlay = () => {
+  return <div>플레이화면 입니다.</div>;
+};
+
+export default GamePlay;

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
+import PointInfo from '../components/PointInfo';
+import CountdownBar from '../components/CountdownBar';
+import TurnInfoBoard from '../components/TurnInfoBoard';
+import NumberInput from '../components/NumberInput';
 
 const GamePlay = () => {
-  return <div>플레이화면 입니다.</div>;
+  return (
+    <div>
+      <PointInfo />
+      <CountdownBar />
+      <TurnInfoBoard />
+      <NumberInput />
+    </div>
+  );
 };
 
 export default GamePlay;

--- a/src/screens/GameStart.tsx
+++ b/src/screens/GameStart.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const GameStart = () => {
+  return <div>시작화면 입니다.</div>;
+};
+
+export default GameStart;


### PR DESCRIPTION
## 연관 이슈
- Close #8 

## 작업 요약
- playMode 여부에 따라 시작 화면, 플레이 화면 컴포넌트 띄워주었습니다.
- 플레이 화면 컴포넌트들 import 해두었습니다.

## 작업 상세 설명
- 여러 페이지가 있는 프로젝트가 아니라서 `src/screens` 폴더 내에 시작화면, 플레이 화면 컴포넌트 위치해두고, `App.tsx`에서 playMode 여부에 따라 컴포넌트 호출해주었습니다.
- `src/components` 폴더 내부에 만들어지는 컴포넌트들 다 넣는 걸로 하면 어떨까합니다.
- 일단 중앙 정렬 처리해두었는데 나중에 합칠 때 중앙 정렬해둔 게 오히려 배치하기 번거로우면 변경될 수 있습니다!
- `playMode` 변수 임의로 변경하여 본인 작업 화면 띄워보시면 됩니다!

## 리뷰 요구사항

> PR 머지되어서 인용문 안 두 항목 신경 안 쓰셔도 됩니다!
> - https://github.com/KEEPER31337/Game-Baseball/pull/10 PR 머지 전이라 이 PR 변경 사항도 포함되어 있습니다! 이 PR 부터 확인하고 와주세요~!
> - [feat : 게임 화면 중앙 정렬](https://github.com/KEEPER31337/Game-Baseball/commit/4f70393cb9cc8ccf04b9d338c2fff45721f33140) 커밋부터 확인하면 됩니다.


- 폴더 구조 혹은 폴더명 관련해서 다른 의견 있으면 코멘트 부탁드립니다!
- 플레이 화면 구성하는 컴포넌트명도 괜찮은 지 의견 부탁드리고, 해당 컴포넌트 작업하시는 분들은 안에 텍스트는 임시 텍스트이니 작업할 때 지우고 작업하면 됩니다.

- Preview 이미지
<img width="400" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/92578a8e-15c8-4014-921a-cdb67c0c65cc">
<img width="400" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/510d8ce4-3afb-48c4-b8bc-8f569d1fcc20">
