### PR TITLE
Feature/안내 모달 구현

### DIFF
--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -26,15 +26,17 @@ const InfoModal = ({ onClose, infoType, results }: InfoModalProps) => {
       sub: null,
     },
   };
-  const [mainInfoText, setMainInfoText] = useState<string>('');
-  const [subInfoText, setSubInfoText] = useState<string>('');
+
+  const [infoText, setInfoText] = useState({ main: '', sub: '' });
 
   const [count, setCount] = useState(3);
   const interval = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
-    setMainInfoText(msg[infoType]?.main || String(results?.guessNumber));
-    setSubInfoText(msg[infoType]?.sub || `STRIKE ${String(results?.strike)} BALL ${String(results?.ball)}`);
+    setInfoText({
+      main: msg[infoType]?.main || String(results?.guessNumber),
+      sub: msg[infoType]?.sub || `STRIKE ${String(results?.strike)} BALL ${String(results?.ball)}`,
+    });
 
     interval.current = setInterval(() => {
       setCount((cnt) => cnt - 1);
@@ -53,8 +55,8 @@ const InfoModal = ({ onClose, infoType, results }: InfoModalProps) => {
   return (
     <div className="absolute left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black/50">
       <div className="flex h-[260px] w-[490px] flex-col justify-center space-y-4 border bg-black text-center text-4xl drop-shadow-[0px_0px_5px_rgba(76,238,249,0.3)]">
-        <p>{mainInfoText}</p>
-        <p className="drop-shadow-[0px_0px_1px_rgba(76,238,249,1)]">{subInfoText}</p>
+        <p>{infoText.main}</p>
+        <p className="drop-shadow-[0px_0px_1px_rgba(76,238,249,1)]">{infoText.sub}</p>
       </div>
     </div>
   );

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -3,38 +3,39 @@ import { ResultDto } from './TurnInfoCard';
 
 interface InfoModalProps {
   onClose: () => void;
-  InfoType: 'win' | 'lose' | 'next' | 'result';
+  infoType: 'win' | 'lose' | 'next' | 'result';
   results?: ResultDto;
 }
 
-const InfoModal = ({ onClose, InfoType, results }: InfoModalProps) => {
+const InfoModal = ({ onClose, infoType, results }: InfoModalProps) => {
+  const msg = {
+    win: {
+      main: 'congraturation',
+      sub: 'YOU WIN!',
+    },
+    lose: {
+      main: 'no more chance',
+      sub: 'GAME OVER',
+    },
+    next: {
+      main: "time's up",
+      sub: 'NEXT TURN',
+    },
+    result: {
+      main: null,
+      sub: null,
+    },
+  };
   const [mainInfoText, setMainInfoText] = useState<string>('');
   const [subInfoText, setSubInfoText] = useState<string>('');
-  useEffect(() => {
-    switch (InfoType) {
-      case 'win':
-        setMainInfoText('congraturation');
-        setSubInfoText('YOU WIN!');
-        break;
-      case 'lose':
-        setMainInfoText('no more chance');
-        setSubInfoText('GAME OVER');
-        break;
-      case 'next':
-        setMainInfoText("time's up");
-        setSubInfoText('NEXT TURN');
-        break;
-      default:
-        setMainInfoText(String(results?.guessNumber));
-        setSubInfoText(`STRIKE ${String(results?.strike)} BALL ${String(results?.ball)}`);
-        break;
-    }
-  }, []);
 
   const [count, setCount] = useState(3);
   const interval = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
+    setMainInfoText(msg[infoType]?.main || String(results?.guessNumber));
+    setSubInfoText(msg[infoType]?.sub || `STRIKE ${String(results?.strike)} BALL ${String(results?.ball)}`);
+
     interval.current = setInterval(() => {
       setCount((cnt) => cnt - 1);
     }, 1000);

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface InfoModalProps {
+  onClose: () => void;
+  InfoType: 'win' | 'lose' | 'next' | 'result';
+  guessNumber?: number;
+  strike?: number;
+  ball?: number;
+}
+
+const InfoModal = ({ onClose, InfoType, guessNumber, strike, ball }: InfoModalProps) => {
+  const [mainInfoText, setMainInfoText] = useState<string>('');
+  const [subInfoText, setSubInfoText] = useState<string>('');
+  useEffect(() => {
+    switch (InfoType) {
+      case 'win':
+        setMainInfoText('congraturation');
+        setSubInfoText('YOU WIN!');
+        break;
+      case 'lose':
+        setMainInfoText('no more chance');
+        setSubInfoText('GAME OVER');
+        break;
+      case 'next':
+        setMainInfoText("time's up");
+        setSubInfoText('NEXT TURN');
+        break;
+      default:
+        setMainInfoText(String(guessNumber));
+        setSubInfoText(`STRIKE ${String(strike)} BALL ${String(ball)}`);
+        break;
+    }
+  }, []);
+
+  const [count, setCount] = useState(3);
+  const interval = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    interval.current = setInterval(() => {
+      setCount((cnt) => cnt - 1);
+    }, 1000);
+
+    return () => clearInterval(interval.current);
+  }, []);
+
+  useEffect(() => {
+    if (count === 1) {
+      clearInterval(interval.current);
+      onClose();
+    }
+  }, [count]);
+
+  return (
+    <div className="absolute left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black/50">
+      <div className="flex h-[260px] w-[490px] flex-col justify-center space-y-4 border bg-black text-center text-4xl drop-shadow-[0px_0px_5px_rgba(76,238,249,0.3)]">
+        <p>{mainInfoText}</p>
+        <p className="drop-shadow-[0px_0px_1px_rgba(76,238,249,1)]">{subInfoText}</p>
+      </div>
+    </div>
+  );
+};
+
+export default InfoModal;

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,14 +1,13 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { ResultDto } from './TurnInfoCard';
 
 interface InfoModalProps {
   onClose: () => void;
   InfoType: 'win' | 'lose' | 'next' | 'result';
-  guessNumber?: number;
-  strike?: number;
-  ball?: number;
+  results?: ResultDto;
 }
 
-const InfoModal = ({ onClose, InfoType, guessNumber, strike, ball }: InfoModalProps) => {
+const InfoModal = ({ onClose, InfoType, results }: InfoModalProps) => {
   const [mainInfoText, setMainInfoText] = useState<string>('');
   const [subInfoText, setSubInfoText] = useState<string>('');
   useEffect(() => {
@@ -26,8 +25,8 @@ const InfoModal = ({ onClose, InfoType, guessNumber, strike, ball }: InfoModalPr
         setSubInfoText('NEXT TURN');
         break;
       default:
-        setMainInfoText(String(guessNumber));
-        setSubInfoText(`STRIKE ${String(strike)} BALL ${String(ball)}`);
+        setMainInfoText(String(results?.guessNumber));
+        setSubInfoText(`STRIKE ${String(results?.strike)} BALL ${String(results?.ball)}`);
         break;
     }
   }, []);

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CiBaseball } from 'react-icons/ci';
 import PointInfo from '../components/PointInfo';
 import CountdownBar from '../components/CountdownBar';
 import TurnInfoBoard from '../components/TurnInfoBoard';
 import NumberInput from '../components/NumberInput';
+import InfoModal from '../components/InfoModal';
 
 const GamePlay = () => {
+  const [infoModalOpen, setInfoModalOpen] = useState<boolean>(false);
+
   return (
     <div>
       <PointInfo />
@@ -18,6 +21,12 @@ const GamePlay = () => {
         <NumberInput />
         <CiBaseball size={50} className="cursor-pointer fill-pointBlue hover:rounded-full hover:bg-pointBlue/20" />
       </div>
+      <button className="bg-pointBlue/50" type="submit" onClick={() => setInfoModalOpen(true)}>
+        confirm modal 버튼
+      </button>
+      {infoModalOpen && (
+        <InfoModal InfoType="result" guessNumber={1234} strike={2} ball={1} onClose={() => setInfoModalOpen(false)} />
+      )}
     </div>
   );
 };

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -25,7 +25,11 @@ const GamePlay = () => {
         confirm modal 버튼
       </button>
       {infoModalOpen && (
-        <InfoModal InfoType="result" guessNumber={1234} strike={2} ball={1} onClose={() => setInfoModalOpen(false)} />
+        <InfoModal
+          InfoType="result"
+          results={{ ball: 0, strike: 2, guessNumber: '1234' }}
+          onClose={() => setInfoModalOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -26,7 +26,7 @@ const GamePlay = () => {
       </button>
       {infoModalOpen && (
         <InfoModal
-          InfoType="result"
+          infoType="result"
           results={{ ball: 0, strike: 2, guessNumber: '1234' }}
           onClose={() => setInfoModalOpen(false)}
         />


### PR DESCRIPTION
## 연관 이슈

- close #2  

## 작업 요약

- 버튼 클릭시 3초간 모달창 뜨도록
- 3초간 어디를 눌러도 모달창이 유지하도록 하기위해, 불투명 배경 깔았습니다.
- 기존에 ResultDto 만들어놓은거 그대로 썼습니다!


## 예시 코드
```tsx
       <InfoModal
          InfoType="result"
          results={{ ball: 0, strike: 2, guessNumber: '1234' }}
          onClose={() => setInfoModalOpen(false)}
        />
       <InfoModal InfoType="next" onClose={() => setInfoModalOpen(false)} />
```
## 리뷰 요구사항

- 리뷰 예상 시간 및 집중 리뷰 부분

- Preview 이미지
![image](https://github.com/KEEPER31337/Game-Baseball/assets/81643702/ffda991e-7dfc-47b1-8388-c4fed491bc26)
![image](https://github.com/KEEPER31337/Game-Baseball/assets/81643702/0c6c6814-4281-4d18-81be-15ac387b6aa1)
