### PR TITLE
Feature/시간 초과 시 모달 설정 #48

### DIFF
--- a/src/components/CountdownBar.tsx
+++ b/src/components/CountdownBar.tsx
@@ -1,19 +1,20 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 interface CountdownBarProps {
   isTurnStart: boolean;
+  initialTimePerTurn: number;
+  turnRemainTime: number;
+  setTurnRemainTime: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const CountdownBar = ({ isTurnStart }: CountdownBarProps) => {
-  const maxCount = 30;
-  const [count, setCount] = useState(maxCount);
+const CountdownBar = ({ isTurnStart, initialTimePerTurn, turnRemainTime, setTurnRemainTime }: CountdownBarProps) => {
   const interval = useRef<NodeJS.Timeout | null>(null);
-  const countPercentage = (count / maxCount) * 100;
+  const countPercentage = (turnRemainTime / initialTimePerTurn) * 100;
 
   const countdownStart = () => {
     if (!interval.current) {
       interval.current = setInterval(() => {
-        setCount((cnt) => cnt - 1);
+        setTurnRemainTime((cnt) => cnt - 1);
       }, 1000);
     }
   };
@@ -26,12 +27,12 @@ const CountdownBar = ({ isTurnStart }: CountdownBarProps) => {
   };
 
   useEffect(() => {
-    if (count < 1) countdownStop();
-  }, [count]);
+    if (turnRemainTime < 1) countdownStop();
+  }, [turnRemainTime]);
 
   useEffect(() => {
     if (isTurnStart === true) {
-      setCount(maxCount);
+      setTurnRemainTime(initialTimePerTurn);
       countdownStart();
     } else countdownStop();
   }, [isTurnStart]);

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ResultInfo } from '../api/dto';
 
+export type InfoType = 'win' | 'lose' | 'next' | 'result';
+
 interface InfoModalProps {
   onClose: () => void;
-  infoType: 'win' | 'lose' | 'next' | 'result';
-  results?: ResultInfo;
+  infoType: InfoType;
+  result?: ResultInfo | null;
 }
 
-const InfoModal = ({ onClose, infoType, results }: InfoModalProps) => {
+const InfoModal = ({ onClose, infoType, result }: InfoModalProps) => {
   const msg = {
     win: {
       main: 'congraturation',
@@ -34,8 +36,8 @@ const InfoModal = ({ onClose, infoType, results }: InfoModalProps) => {
 
   useEffect(() => {
     setInfoText({
-      main: msg[infoType]?.main || String(results?.guessNumber),
-      sub: msg[infoType]?.sub || `STRIKE ${String(results?.strike)} BALL ${String(results?.ball)}`,
+      main: msg[infoType]?.main || String(result?.guessNumber),
+      sub: msg[infoType]?.sub || `STRIKE ${String(result?.strike)} BALL ${String(result?.ball)}`,
     });
 
     interval.current = setInterval(() => {

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -1,11 +1,11 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { CiBaseball } from 'react-icons/ci';
 import { AuthCodeRef } from 'react-auth-code-input';
 import PointInfo from '../components/PointInfo';
 import CountdownBar from '../components/CountdownBar';
 import TurnInfoBoard from '../components/TurnInfoBoard';
 import NumberInput from '../components/NumberInput';
-import InfoModal from '../components/InfoModal';
+import InfoModal, { InfoType } from '../components/InfoModal';
 import { useGuessMutation, useGetGameInfoQuery } from '../api/baseballApi';
 import { ResultInfo } from '../api/dto';
 
@@ -14,7 +14,12 @@ const INITIAL_TIME_PER_TURN = 30;
 const GamePlay = () => {
   const [guessNumber, setGuessNumber] = useState('');
   const [turnRemainTime, setTurnRemainTime] = useState(INITIAL_TIME_PER_TURN);
-  const [infoModalSetting, setInfoModalSetting] = useState<{ open: boolean; result: ResultInfo | null }>({
+  const [infoModalSetting, setInfoModalSetting] = useState<{
+    type: InfoType;
+    open: boolean;
+    result: ResultInfo | null;
+  }>({
+    type: 'result',
     open: false,
     result: null,
   });
@@ -29,11 +34,21 @@ const GamePlay = () => {
       {
         onSuccess: (data) => {
           AuthInputRef.current?.clear();
-          setInfoModalSetting({ open: true, result: data.results.at(-1) });
+          setInfoModalSetting({ type: 'result', open: true, result: data.results.at(-1) });
         },
       },
     );
   };
+
+  useEffect(() => {
+    if (turnRemainTime === 0) {
+      setInfoModalSetting({
+        type: 'next',
+        open: true,
+        result: null,
+      });
+    }
+  }, [turnRemainTime]);
 
   if (gameInfoLoading || !gameInfo) return null;
   return (
@@ -60,10 +75,10 @@ const GamePlay = () => {
           <CiBaseball size={50} className=" fill-pointBlue group-disabled:fill-pointBlue/20" />
         </button>
       </div>
-      {infoModalSetting.open && infoModalSetting.result && (
+      {infoModalSetting.open && (
         <InfoModal
-          infoType="result"
-          results={infoModalSetting.result}
+          infoType={infoModalSetting.type}
+          result={infoModalSetting.result}
           onClose={() => setInfoModalSetting((prev) => ({ ...prev, open: false }))}
         />
       )}

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -9,8 +9,11 @@ import InfoModal from '../components/InfoModal';
 import { useGuessMutation, useGetGameInfoQuery } from '../api/baseballApi';
 import { ResultInfo } from '../api/dto';
 
+const INITIAL_TIME_PER_TURN = 30;
+
 const GamePlay = () => {
   const [guessNumber, setGuessNumber] = useState('');
+  const [turnRemainTime, setTurnRemainTime] = useState(INITIAL_TIME_PER_TURN);
   const [infoModalSetting, setInfoModalSetting] = useState<{ open: boolean; result: ResultInfo | null }>({
     open: false,
     result: null,
@@ -36,7 +39,12 @@ const GamePlay = () => {
   return (
     <div>
       <PointInfo earnablePoint={0} />
-      <CountdownBar isTurnStart />
+      <CountdownBar
+        isTurnStart
+        initialTimePerTurn={INITIAL_TIME_PER_TURN}
+        turnRemainTime={turnRemainTime}
+        setTurnRemainTime={setTurnRemainTime}
+      />
       <TurnInfoBoard
         results={[{ ball: 1, strike: 2, guessNumber: '1234' }, null, { ball: 2, strike: 1, guessNumber: '2345' }]}
         round={gameInfo.tryCount}


### PR DESCRIPTION
## 연관 이슈

- Close #48 

## 작업 요약

- 시간 0초된 시점에 시간 초과 모달 띄우도록 처리하였습니다.

## 작업 상세 설명

- `useEffect`에서 남은 시간 변경 주시하고 있다가 0이 되는 시점에 modal open 상태로 변경해주었습니다.

## 리뷰 요구사항

- `5분`

## Preview 이미지
<img width="821" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/9dfca6c7-3cdc-4ae8-b4dd-df2bf91841b7">
