### PR TITLE
Feature/게임 화면 다시 접근 시 보여줄 화면 처리 #54

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,35 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import GameStart from './screens/GameStart';
 import GamePlay from './screens/GamePlay';
-import { useGameStartMutation, useGetIsAlreadyPlayedQuery, useGetResultQuery } from './api/baseballApi';
+import { useGameStartMutation, useGetBaseBallStatusQuery } from './api/baseballApi';
 
 const App = () => {
   const [bettingPoint, setBettingPoint] = useState<string>('');
   const [playMode, setPlayMode] = useState(false);
   const { mutate: gameStart } = useGameStartMutation();
-  const { data: isPlayed } = useGetIsAlreadyPlayedQuery();
-  const { data: currentGameCondition } = useGetResultQuery(isPlayed ?? false);
+  const { data: baseballStatus } = useGetBaseBallStatusQuery();
 
   const handleStart = () => {
     gameStart({ bettingPoint: Number(bettingPoint) });
     setPlayMode(true);
   };
 
+  useEffect(() => {
+    if (baseballStatus?.status === 'PLAYING') {
+      setPlayMode(true);
+      return;
+    }
+    setPlayMode(false);
+  }, [baseballStatus]);
+
+  if (!baseballStatus) return null;
   return (
     <div className="grid h-screen w-screen place-items-center bg-mainBlack">
-      {playMode && currentGameCondition ? (
-        <GamePlay bettingPoint={bettingPoint} currentGameCondition={currentGameCondition} />
+      {playMode ? (
+        <GamePlay bettingPoint={bettingPoint} />
       ) : (
         <GameStart
-          isPlayed={isPlayed ?? false}
+          status={baseballStatus.status}
           onStart={handleStart}
           bettingPoint={bettingPoint}
           setBettingPoint={setBettingPoint}

--- a/src/api/baseballApi.ts
+++ b/src/api/baseballApi.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { useQuery, useMutation } from 'react-query';
-import { GameInfo, GameResultInfo } from './dto';
+import { GameInfo, GameResultInfo, GameStatus } from './dto';
 
 const quearyKeys = {
   game_info: ['game_info'] as const,
-  is_already_played: ['is_already_played'] as const,
+  status: ['status'] as const,
   result: ['result'] as const,
 };
 
@@ -14,10 +14,10 @@ const useGetGameInfoQuery = () => {
   return useQuery<GameInfo>(quearyKeys.game_info, fetcher);
 };
 
-const useGetIsAlreadyPlayedQuery = () => {
-  const fetcher = () => axios.get('/game/baseball/is-already-played').then(({ data }) => data);
+const useGetBaseBallStatusQuery = () => {
+  const fetcher = () => axios.get('/game/baseball/status').then(({ data }) => data);
 
-  return useQuery<boolean>(quearyKeys.is_already_played, fetcher);
+  return useQuery<{ status: GameStatus; baseballPerDay: number }>(quearyKeys.status, fetcher);
 };
 
 const useGameStartMutation = () => {
@@ -34,11 +34,9 @@ const useGuessMutation = () => {
   return useMutation(fetcher);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const useGetResultQuery = (isPlayed: boolean) => {
+const useGetResultQuery = () => {
   const fetcher = () => axios.get('/game/baseball/result').then(({ data }) => data);
-  /* TODO 백엔드 횟수제한 1회로 다시 맞춰지면 enabled에 isPlayed 적용해야 함 */
-  return useQuery<GameResultInfo>(quearyKeys.result, fetcher, { enabled: true });
+  return useQuery<GameResultInfo>(quearyKeys.result, fetcher);
 };
 
-export { useGetGameInfoQuery, useGetIsAlreadyPlayedQuery, useGameStartMutation, useGuessMutation, useGetResultQuery };
+export { useGetGameInfoQuery, useGetBaseBallStatusQuery, useGameStartMutation, useGuessMutation, useGetResultQuery };

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -15,3 +15,5 @@ export interface GameInfo {
   maxBettingPoint: number;
   minBettingPoint: number;
 }
+
+export type GameStatus = 'NOT_START' | 'PLAYING' | 'END';

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -6,19 +6,18 @@ import CountdownBar from '../components/CountdownBar';
 import TurnInfoBoard from '../components/TurnInfoBoard';
 import NumberInput from '../components/NumberInput';
 import InfoModal, { InfoType } from '../components/InfoModal';
-import { useGuessMutation, useGetGameInfoQuery } from '../api/baseballApi';
+import { useGuessMutation, useGetGameInfoQuery, useGetResultQuery } from '../api/baseballApi';
 import { GameResultInfo, ResultInfo } from '../api/dto';
 
 const INITIAL_TIME_PER_TURN = 30;
 
 interface GamePlayProps {
   bettingPoint: string;
-  currentGameCondition: GameResultInfo;
 }
 
-const GamePlay = ({ bettingPoint, currentGameCondition }: GamePlayProps) => {
+const GamePlay = ({ bettingPoint }: GamePlayProps) => {
   const [guessNumber, setGuessNumber] = useState('');
-  const [gameResults, setGameResults] = useState<(ResultInfo | null)[]>(currentGameCondition.results);
+  const [gameResults, setGameResults] = useState<(ResultInfo | null)[]>([]);
   const [turnRemainTime, setTurnRemainTime] = useState(INITIAL_TIME_PER_TURN);
   const [infoModalSetting, setInfoModalSetting] = useState<{
     type: InfoType;
@@ -30,6 +29,7 @@ const GamePlay = ({ bettingPoint, currentGameCondition }: GamePlayProps) => {
     result: null,
   });
   const { data: gameInfo, isLoading: gameInfoLoading } = useGetGameInfoQuery();
+  const { data: currentGameCondition } = useGetResultQuery();
 
   const AuthInputRef = useRef<AuthCodeRef>(null);
   const { mutate: guess } = useGuessMutation();
@@ -57,6 +57,12 @@ const GamePlay = ({ bettingPoint, currentGameCondition }: GamePlayProps) => {
       setGameResults((prev) => [...prev, null]);
     }
   }, [turnRemainTime]);
+
+  useEffect(() => {
+    if (currentGameCondition) {
+      setGameResults(currentGameCondition.results);
+    }
+  }, [currentGameCondition]);
 
   if (gameInfoLoading || !gameInfo) return null;
   return (

--- a/src/screens/GameStart.tsx
+++ b/src/screens/GameStart.tsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import { useGetGameInfoQuery } from '../api/baseballApi';
+import { GameStatus } from '../api/dto';
 
 interface GameStartProps {
   onStart: () => void;
-  isPlayed: boolean;
+  status: GameStatus;
   bettingPoint: string;
   setBettingPoint: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const GameStart = ({ onStart, isPlayed, bettingPoint, setBettingPoint }: GameStartProps) => {
+const GameStart = ({ onStart, status, bettingPoint, setBettingPoint }: GameStartProps) => {
   const { data: gameInfo, isLoading: gameInfoLoading } = useGetGameInfoQuery();
-  const gamePlayedMessage = isPlayed ? "You've already played the game!" : 'betting your point...';
+  const gamePlayedMessage = {
+    NOT_START: 'betting your point...',
+    END: "You've already played the game!",
+    PLAYING: null,
+  };
 
   if (gameInfoLoading || !gameInfo) return null;
   return (
     <div className="flex h-full w-full flex-col place-content-center place-items-center">
       <div className="mb-10 text-[40px] font-bold text-pointBlue">BASEBALL GAME</div>
-      <div className="mb-10 text-2xl">{gamePlayedMessage}</div>
-      {!isPlayed && (
+      <div className="mb-10 text-2xl">{gamePlayedMessage[status]}</div>
+      {status === 'NOT_START' && (
         <>
           <input
             value={bettingPoint}


### PR DESCRIPTION
## 연관 이슈

- Close #54 

## 작업 요약

- API 변경 (예정) 사항 적용하였고, 게임 상태별 화면 처리해주었습니다.

## 작업 상세 설명

- `NOT_START`와 `END`일 때는 게임 시작 화면, `PLAYING`일때는 게임 플레이 화면 보이도록 처리하였습니다.
-  게임 시작 화면에서 `NOT_START`일때와 `END`일 때 구분하여 문구 띄워주도록 처리하였습니다.

## 리뷰 요구사항

- 선행 PR #57 먼저 리뷰 부탁드립니다!
- 이 PR은 [feat : 변경된 api 양식 적용 및 status에 따른 화면 제어](https://github.com/KEEPER31337/Game-Baseball/commit/31315cd82deb06900b44dd5214e9038d740c5f86) 이 커밋만 보시면 됩니다!
- 아직 API 변경사항이 머지 된 건 아니라서 정상적으로 실행 하는 지는 테스트 못해봤습니다. merge 하기전 테스트 후 merge 해보겠습니다.  
  변경된 API 아래 이미지 참고해주세요!
  <img width="500" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/05583b2c-6e89-4d4c-a70e-d989e9289c96">
