### PR TITLE
Feature/첫글자 0일때 버튼 비활성화 되는 버그 픽스 #59

### DIFF
--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -70,7 +70,7 @@ const GamePlay = () => {
           type="button"
           className="group enabled:cursor-pointer enabled:hover:rounded-full enabled:hover:bg-pointBlue/20 "
           onClick={handleGuessClick}
-          disabled={Number(guessNumber) < 1000 || Number(guessNumber) > 9999}
+          disabled={guessNumber.length !== gameInfo.guessNumberLength}
         >
           <CiBaseball size={50} className=" fill-pointBlue group-disabled:fill-pointBlue/20" />
         </button>


### PR DESCRIPTION
## 연관 이슈

- Close #59

## 작업 요약

- 게임 규칙상 0~9 숫자 입력이 가능한데 첫글자 0으로 들어가면 버튼이 비활성화되는 이슈가 있어서 해결해주었습니다.

## 작업 상세 설명

- 비활성화 기준이 1000 <= Number(guessNumber) <= 9999 이었는데 숫자로 판별할 경우 첫글자가 0일 때 판별이 쉽지 않아 string으로 관리되고 있는 `guessNumber`의 길이로 판단해주었습니다. 인풋 자체에서 숫자만 받고 있기 때문에 다른 문자가 들어갈 수 있는 가능성은 별도로 체크하지 않아도 될 것 같습니다.

## 리뷰 요구사항

- 예상 소요 시간 1분
- 비활성화 조건 이걸로 충분한 지 체크 부탁드려요!

## Preview 이미지
<img width="331" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/2b159b09-0249-42f0-bffb-fb95dbaff7ae">
