### PR TITLE
게임 종료 시 종료 문구 띄워주고 게임 멈추기 #58

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ const App = () => {
 
   if (!baseballStatus) return null;
   return (
-    <div className="grid h-screen w-screen place-items-center bg-mainBlack">
+    <div className="relative grid h-screen w-screen select-none place-items-center bg-mainBlack">
       {playMode ? (
         <GamePlay bettingPoint={bettingPoint} />
       ) : (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,11 @@ const App = () => {
   };
 
   useEffect(() => {
-    if (baseballStatus?.status === 'PLAYING') {
-      setPlayMode(true);
+    if (!baseballStatus || baseballStatus.status === 'NOT_START') {
+      setPlayMode(false);
       return;
     }
-    setPlayMode(false);
+    setPlayMode(true);
   }, [baseballStatus]);
 
   if (!baseballStatus) return null;
@@ -28,12 +28,7 @@ const App = () => {
       {playMode ? (
         <GamePlay bettingPoint={bettingPoint} />
       ) : (
-        <GameStart
-          status={baseballStatus.status}
-          onStart={handleStart}
-          bettingPoint={bettingPoint}
-          setBettingPoint={setBettingPoint}
-        />
+        <GameStart onStart={handleStart} bettingPoint={bettingPoint} setBettingPoint={setBettingPoint} />
       )}
     </div>
   );

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ResultInfo } from '../api/dto';
 
-export type InfoType = 'win' | 'lose' | 'next' | 'result';
+export type InfoType = 'next' | 'result';
 
 interface InfoModalProps {
   onClose: () => void;
@@ -11,14 +11,6 @@ interface InfoModalProps {
 
 const InfoModal = ({ onClose, infoType, result }: InfoModalProps) => {
   const msg = {
-    win: {
-      main: 'congraturation',
-      sub: 'YOU WIN!',
-    },
-    lose: {
-      main: 'no more chance',
-      sub: 'GAME OVER',
-    },
     next: {
       main: "time's up",
       sub: 'NEXT TURN',

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -53,7 +53,7 @@ const InfoModal = ({ onClose, infoType, result }: InfoModalProps) => {
   }, [count]);
 
   return (
-    <div className="absolute left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black/50">
+    <div className="absolute left-0 top-0 z-20 flex h-screen w-screen items-center justify-center bg-black/50">
       <div className="flex h-[260px] w-[490px] flex-col justify-center space-y-4 border bg-black text-center text-4xl drop-shadow-[0px_0px_5px_rgba(76,238,249,0.3)]">
         <p>{msg[infoType].main}</p>
         <p className="drop-shadow-[0px_0px_1px_rgba(76,238,249,1)]">{msg[infoType].sub}</p>

--- a/src/components/NoticeEnd.tsx
+++ b/src/components/NoticeEnd.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export type EndType = 'win' | 'lose';
+
+interface NoticeEndProps {
+  endType: EndType;
+}
+
+const NoticeEnd = ({ endType }: NoticeEndProps) => {
+  const msg = {
+    win: {
+      main: 'congraturation',
+      sub: 'YOU WIN!',
+    },
+    lose: {
+      main: 'no more chance',
+      sub: 'GAME OVER',
+    },
+  };
+
+  return (
+    <div className="absolute left-0 top-0 z-10 flex h-screen w-screen flex-col items-center justify-center bg-black/70 text-center active:hidden">
+      <p className="text-2xl font-semibold">{msg[endType].main}</p>
+      <p className="text-2xl font-semibold text-pointBlue">{msg[endType].sub}</p>
+      <p className="mt-2 text-[10px] text-gray-400">
+        오늘 게임 횟수를 모두 소진하였습니다.
+        <br />
+        선명한 현황판을 보고 싶다면 화면을 눌러주세요.
+      </p>
+    </div>
+  );
+};
+
+export default NoticeEnd;

--- a/src/components/TurnInfoBoard.tsx
+++ b/src/components/TurnInfoBoard.tsx
@@ -3,12 +3,14 @@ import TurnInfoCard from './TurnInfoCard';
 import { ResultInfo } from '../api/dto';
 
 interface TurnInfoBoardProps {
+  isWin: boolean;
   results: Array<ResultInfo | null>;
   round: number;
 }
 
-const TurnInfoBoard = ({ results, round }: TurnInfoBoardProps) => {
+const TurnInfoBoard = ({ isWin, results, round }: TurnInfoBoardProps) => {
   const renderList: Array<'Ready' | 'Playing' | 'Finished'> = Array.from({ length: round }, (v, i) => {
+    if (isWin) return 'Finished';
     if (i === results.length) return 'Playing';
     if (i > results.length) return 'Ready';
     return 'Finished';

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -8,6 +8,7 @@ import NumberInput from '../components/NumberInput';
 import InfoModal, { InfoType } from '../components/InfoModal';
 import { useGuessMutation, useGetGameInfoQuery, useGetResultQuery } from '../api/baseballApi';
 import { ResultInfo } from '../api/dto';
+import NoticeEnd from '../components/NoticeEnd';
 
 const INITIAL_TIME_PER_TURN = 30;
 const MOBLIE_MAX_WIDTH = 768;
@@ -31,6 +32,7 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
   const { data: gameInfo, isLoading: gameInfoLoading } = useGetGameInfoQuery();
   const { data: currentGameCondition } = useGetResultQuery();
   const isWin: boolean = (gameInfo && gameResults.at(-1)?.strike === gameInfo.guessNumberLength) ?? false;
+  const isLose: boolean = (gameInfo && gameResults.length === gameInfo.tryCount && !isWin) ?? false;
 
   const AuthInputRef = useRef<AuthCodeRef>(null);
   const { mutate: guess } = useGuessMutation();
@@ -80,7 +82,7 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
       <PointInfo earnablePoint={bettingPoint} />
       {innerWidth > MOBLIE_MAX_WIDTH && <div className="my-5" />}
       <CountdownBar
-        isTurnStart={!isWin && isTurnStart}
+        isTurnStart={!isWin && !isLose && isTurnStart}
         initialTimePerTurn={INITIAL_TIME_PER_TURN}
         turnRemainTime={turnRemainTime}
         setTurnRemainTime={setTurnRemainTime}
@@ -88,7 +90,7 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
       {innerWidth > MOBLIE_MAX_WIDTH && <div className="my-8" />}
       <TurnInfoBoard isWin={isWin} results={gameResults} round={gameInfo.tryCount} />
       {innerWidth > MOBLIE_MAX_WIDTH && <div className="my-8" />}
-      {!isWin && (
+      {!isWin && !isLose && (
         <div className="flex items-center space-x-4">
           <NumberInput AuthInputRef={AuthInputRef} onChange={(res: string) => setGuessNumber(res)} />
           <button
@@ -110,17 +112,8 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
           }}
         />
       )}
-      {isWin && (
-        <div className="absolute left-0 top-0 z-10 flex h-screen w-screen flex-col items-center justify-center bg-black/70 active:hidden">
-          <p className="text-center text-2xl font-semibold">congraturation</p>
-          <p className="text-center text-2xl font-semibold text-pointBlue">YOU WIN!</p>
-          <p className="mt-2 text-center text-[10px] text-gray-400">
-            오늘 게임 횟수를 모두 소진하였습니다.
-            <br />
-            선명한 현황판을 보고 싶다면 화면을 눌러주세요.
-          </p>
-        </div>
-      )}
+      {isWin && <NoticeEnd endType="win" />}
+      {isLose && <NoticeEnd endType="lose" />}
     </div>
   );
 };

--- a/src/screens/GamePlay.tsx
+++ b/src/screens/GamePlay.tsx
@@ -7,7 +7,7 @@ import TurnInfoBoard from '../components/TurnInfoBoard';
 import NumberInput from '../components/NumberInput';
 import InfoModal, { InfoType } from '../components/InfoModal';
 import { useGuessMutation, useGetGameInfoQuery, useGetResultQuery } from '../api/baseballApi';
-import { GameResultInfo, ResultInfo } from '../api/dto';
+import { ResultInfo } from '../api/dto';
 
 const INITIAL_TIME_PER_TURN = 30;
 const MOBLIE_MAX_WIDTH = 768;
@@ -30,6 +30,7 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
   });
   const { data: gameInfo, isLoading: gameInfoLoading } = useGetGameInfoQuery();
   const { data: currentGameCondition } = useGetResultQuery();
+  const isWin: boolean = (gameInfo && gameResults.at(-1)?.strike === gameInfo.guessNumberLength) ?? false;
 
   const AuthInputRef = useRef<AuthCodeRef>(null);
   const { mutate: guess } = useGuessMutation();
@@ -79,25 +80,27 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
       <PointInfo earnablePoint={bettingPoint} />
       {innerWidth > MOBLIE_MAX_WIDTH && <div className="my-5" />}
       <CountdownBar
-        isTurnStart={isTurnStart}
+        isTurnStart={!isWin && isTurnStart}
         initialTimePerTurn={INITIAL_TIME_PER_TURN}
         turnRemainTime={turnRemainTime}
         setTurnRemainTime={setTurnRemainTime}
       />
       {innerWidth > MOBLIE_MAX_WIDTH && <div className="my-8" />}
-      <TurnInfoBoard results={gameResults} round={gameInfo.tryCount} />
+      <TurnInfoBoard isWin={isWin} results={gameResults} round={gameInfo.tryCount} />
       {innerWidth > MOBLIE_MAX_WIDTH && <div className="my-8" />}
-      <div className="flex items-center space-x-4">
-        <NumberInput AuthInputRef={AuthInputRef} onChange={(res: string) => setGuessNumber(res)} />
-        <button
-          type="button"
-          className="group enabled:cursor-pointer enabled:hover:rounded-full enabled:hover:bg-pointBlue/20 "
-          onClick={handleGuessClick}
-          disabled={guessNumber.length !== gameInfo.guessNumberLength}
-        >
-          <CiBaseball size={50} className=" fill-pointBlue group-disabled:fill-pointBlue/20" />
-        </button>
-      </div>
+      {!isWin && (
+        <div className="flex items-center space-x-4">
+          <NumberInput AuthInputRef={AuthInputRef} onChange={(res: string) => setGuessNumber(res)} />
+          <button
+            type="button"
+            className="group enabled:cursor-pointer enabled:hover:rounded-full enabled:hover:bg-pointBlue/20"
+            onClick={handleGuessClick}
+            disabled={guessNumber.length !== gameInfo.guessNumberLength}
+          >
+            <CiBaseball size={50} className="fill-pointBlue group-disabled:fill-pointBlue/20" />
+          </button>
+        </div>
+      )}
       {!isTurnStart && (
         <InfoModal
           infoType={infoModalSetting.type}
@@ -106,6 +109,17 @@ const GamePlay = ({ bettingPoint }: GamePlayProps) => {
             setIsTurnStart(true);
           }}
         />
+      )}
+      {isWin && (
+        <div className="absolute left-0 top-0 z-10 flex h-screen w-screen flex-col items-center justify-center bg-black/70 active:hidden">
+          <p className="text-center text-2xl font-semibold">congraturation</p>
+          <p className="text-center text-2xl font-semibold text-pointBlue">YOU WIN!</p>
+          <p className="mt-2 text-center text-[10px] text-gray-400">
+            오늘 게임 횟수를 모두 소진하였습니다.
+            <br />
+            선명한 현황판을 보고 싶다면 화면을 눌러주세요.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/src/screens/GameStart.tsx
+++ b/src/screens/GameStart.tsx
@@ -1,51 +1,40 @@
 import React from 'react';
 import { useGetGameInfoQuery } from '../api/baseballApi';
-import { GameStatus } from '../api/dto';
 
 interface GameStartProps {
   onStart: () => void;
-  status: GameStatus;
   bettingPoint: string;
   setBettingPoint: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const GameStart = ({ onStart, status, bettingPoint, setBettingPoint }: GameStartProps) => {
+const GameStart = ({ onStart, bettingPoint, setBettingPoint }: GameStartProps) => {
   const { data: gameInfo, isLoading: gameInfoLoading } = useGetGameInfoQuery();
-  const gamePlayedMessage = {
-    NOT_START: 'betting your point...',
-    END: "You've already played the game!",
-    PLAYING: null,
-  };
 
   if (gameInfoLoading || !gameInfo) return null;
   return (
     <div className="flex h-full w-full flex-col place-content-center place-items-center">
       <div className="mb-10 text-[40px] font-bold text-pointBlue">BASEBALL GAME</div>
-      <div className="mb-10 text-2xl">{gamePlayedMessage[status]}</div>
-      {status === 'NOT_START' && (
-        <>
-          <input
-            value={bettingPoint}
-            onChange={(e) => {
-              const value = e.target.value.replace(/[^0-9]/g, '');
-              if (value === '0') setBettingPoint(String(gameInfo.minBettingPoint));
-              else if (gameInfo.maxBettingPoint < Number(value)) setBettingPoint(String(gameInfo.maxBettingPoint));
-              else setBettingPoint(value);
-            }}
-            className="mb-20 w-[400px] border-[1px] border-pointBlue bg-transparent text-center text-[40px] focus:outline-none"
-            type="text"
-            placeholder={`${gameInfo.minBettingPoint} ~ ${gameInfo.maxBettingPoint}`}
-          />
-          <button
-            disabled={parseInt(bettingPoint, 10) < gameInfo.minBettingPoint || bettingPoint === ''}
-            className="text-2xl enabled:hover:text-pointBlue disabled:text-gray-500"
-            onClick={onStart}
-            type="button"
-          >
-            START
-          </button>
-        </>
-      )}
+      <div className="mb-10 text-2xl">betting your point...</div>
+      <input
+        value={bettingPoint}
+        onChange={(e) => {
+          const value = e.target.value.replace(/[^0-9]/g, '');
+          if (value === '0') setBettingPoint(String(gameInfo.minBettingPoint));
+          else if (gameInfo.maxBettingPoint < Number(value)) setBettingPoint(String(gameInfo.maxBettingPoint));
+          else setBettingPoint(value);
+        }}
+        className="mb-20 w-[400px] border-[1px] border-pointBlue bg-transparent text-center text-[40px] focus:outline-none"
+        type="text"
+        placeholder={`${gameInfo.minBettingPoint} ~ ${gameInfo.maxBettingPoint}`}
+      />
+      <button
+        disabled={parseInt(bettingPoint, 10) < gameInfo.minBettingPoint || bettingPoint === ''}
+        className="text-2xl enabled:hover:text-pointBlue disabled:text-gray-500"
+        onClick={onStart}
+        type="button"
+      >
+        START
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## 연관 이슈

- Close #58

## 작업 요약

- 게임 승리 시나, 게임 질 시에 관련된 처리 해주었습니다.

## 작업 상세 설명

- 게임 승리하면 게임 결과 모달 뜨고 승리 문구 띄워주도록 처리하였습니다. (졌을 때도 마찬가지)
- 게임 완료 화면 대신 해당 승리/짐 문구 떠있는 화면을 유지하도록 처리하였고, 클릭하고 있을 시 문구 없애고 현황판 깔끔하게 볼 수 있도록 처리해주었습니다.

## 리뷰 요구사항

- 10분 소요 예상

## Preview 이미지
<img width="300" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/3e0f166e-47dd-461f-bef9-db5308043f92"> <img width="300" alt="image" src="https://github.com/KEEPER31337/Game-Baseball/assets/78250089/de49e400-8ff3-4fdd-89f3-cd9ed5d928b1">


누르고 있을 때 성공/실패 문구 사라지고 선명하게 진행상황 볼 수 있습니다!
(근데 저희 게임 좀 많이 어려운 것 같아효...ㅎㅎ 4스트라이크 맞추기 쉽지 않다ㅏㅏ///)

https://github.com/KEEPER31337/Game-Baseball/assets/78250089/16ab20da-8c60-415a-8153-9e977a626fdb

이거는 일부러 진 겁니다..!! ㅎㅎ

https://github.com/KEEPER31337/Game-Baseball/assets/78250089/dce23e02-d178-4399-8ac6-caaff52897d9


